### PR TITLE
Disable debugger in prod builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"format": "prettier . --write",
 		"format:check": "prettier . --check",
 		"build": "vite build && vite-node bin/build.ts prod",
-		"dev": "vite build --watch"
+		"dev": "NODE_ENV=development vite build --watch"
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.13.0",

--- a/source/lib/debug.ts
+++ b/source/lib/debug.ts
@@ -3,13 +3,21 @@ class Debug {
 	 * Log low-level debug information.
 	 */
 	debug(...args: any[]) {
-		console.info(...args);
+		if(import.meta.env.DEV) console.info(...args);
 	}
 	/**
 	 * Log warnings about something.
 	 */
 	warn(...args: any[]) {
-		console.warn(...args);
+		// TODO: add some telemetry here
+		if(import.meta.env.DEV) console.warn(...args);
+	}
+	/**
+	 * Log serious errors that are breaking something.
+	 */
+	error(...args: any[]) {
+		// TODO: add some telemetry here
+		console.error(...args);
 	}
 }
 

--- a/source/lib/debug.ts
+++ b/source/lib/debug.ts
@@ -3,14 +3,14 @@ class Debug {
 	 * Log low-level debug information.
 	 */
 	debug(...args: any[]) {
-		if(import.meta.env.DEV) console.info(...args);
+		if (import.meta.env.DEV) console.info(...args);
 	}
 	/**
 	 * Log warnings about something.
 	 */
 	warn(...args: any[]) {
 		// TODO: add some telemetry here
-		if(import.meta.env.DEV) console.warn(...args);
+		if (import.meta.env.DEV) console.warn(...args);
 	}
 	/**
 	 * Log serious errors that are breaking something.


### PR DESCRIPTION
This way we don't spew random debug info in production builds