### PR TITLE
Ignore scan results from inactive tabs

### DIFF
--- a/source/lib/activeTab.ts
+++ b/source/lib/activeTab.ts
@@ -1,0 +1,15 @@
+import browser from "./browser";
+
+export async function getActiveTab(): Promise<browser.tabs.Tab | undefined> {
+	let activeTab: browser.tabs.Tab | undefined;
+	if (import.meta.env?.MODE === "test") {
+		activeTab = (await browser.tabs.query({}))[1];
+	} else {
+		[activeTab] = await browser.tabs.query({
+			active: true,
+			currentWindow: true,
+			windowType: "normal",
+		});
+	}
+	return activeTab;
+}

--- a/source/lib/communication.ts
+++ b/source/lib/communication.ts
@@ -4,6 +4,8 @@ import { StorageKey } from "./StorageKey.ts";
 import { scanState } from "./ScanState.ts";
 import { PluginResultSchema } from "./pluginTypes.ts";
 
+export const getTabIdRequest = "getTabId";
+
 export type RequestDetails = browser.webRequest._OnBeforeRequestDetails &
 	Partial<browser.webRequest._OnBeforeRedirectDetails> &
 	Partial<browser.webRequest._OnCompletedDetails> &
@@ -65,7 +67,13 @@ class Storage {
 	/**
 	 * The ID of the currently running analysis.
 	 */
-	analysisId = new StorageKey("AnalysisId", z.string());
+	analysisMeta = new StorageKey(
+		"AnalysisMeta",
+		z.object({
+			id: z.string(),
+			targetTab: z.number(),
+		}),
+	);
 	/**
 	 * The final results after analysis has completed.
 	 */

--- a/source/views/ScanOptionsView.svelte
+++ b/source/views/ScanOptionsView.svelte
@@ -12,6 +12,8 @@
 	import DomSelect from "./components/DomSelect.svelte";
 
 	import { onMount } from "svelte";
+	import { getActiveTab } from "../lib/activeTab.ts";
+	import debug from "../lib/debug.ts";
 
 	let NavTabs: Tab[] = $state([
 		{ label: TabType.PLUGINS, title: "Plugin Selection" },
@@ -24,7 +26,15 @@
 	let selectedPlugins: { name: string; checked: boolean }[] = $state([]);
 
 	async function startScan() {
-		await storage.analysisId.set(crypto.randomUUID());
+		const targetTab = await getActiveTab();
+		if (!targetTab?.id) {
+			debug.error("Could not start scanning, no tab id");
+			return;
+		}
+		await storage.analysisMeta.set({
+			id: crypto.randomUUID(),
+			targetTab: targetTab.id,
+		});
 		await storage.analysisResults.clear();
 		statusMessageStore.set([]);
 


### PR DESCRIPTION
This ensures that we only include content scan results for the currently active tab, meaning that you will no longer accidentally see results from other sites.